### PR TITLE
chore: added fastify & express skills

### DIFF
--- a/src/app/_partial/skillsBox/skillsBox.config.tsx
+++ b/src/app/_partial/skillsBox/skillsBox.config.tsx
@@ -15,6 +15,8 @@ import { IoLanguage } from "react-icons/io5";
 import { RiNextjsLine } from "react-icons/ri";
 import {
   SiAstro,
+  SiExpress,
+  SiFastify,
   SiHibernate,
   SiPostgresql,
   SiSpring,
@@ -57,6 +59,14 @@ export function useToolCategories() {
             name: "Astro",
             icon: <SiAstro color="#FF5A03" />,
           },
+          {
+            name: "Fastify",
+            icon: <SiFastify color="white" />,
+          },
+          {
+            name: "Express",
+            icon: <SiExpress color="white" />,
+          },
         ],
       },
       {
@@ -80,7 +90,7 @@ export function useToolCategories() {
             icon: <GrMysql />,
           },
           {
-            name: "Sass/CSS",
+            name: "CSS/Sass",
             icon: <FaCss3Alt />,
           },
           {


### PR DESCRIPTION
This pull request updates the `skillsBox.config.tsx` file to add new tools and make a minor adjustment to an existing tool's name. Below are the key changes:

### Additions to tool categories:

* Added `Fastify` and `Express` to the tool categories, including their respective icons with specified colors. [[1]](diffhunk://#diff-d73855f37ca1d92c073129ff537b24ef490992e1d5bd15e021aacc3c10c58239R18-R19) [[2]](diffhunk://#diff-d73855f37ca1d92c073129ff537b24ef490992e1d5bd15e021aacc3c10c58239R62-R69)

### Modifications to existing tool names:

* Renamed the tool category `Sass/CSS` to `CSS/Sass` for consistency or clarity.